### PR TITLE
Change "Pair" for "Even"

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <h1 class="title">Counter in Vanilla JS</h1>
   <div class="section">
     <div class="info">
-      <p id="pair" class="type">Pair</p>
+      <p id="pair" class="type">Even</p>
       <p id="count" class="count zero">0</p>
       <p id="odd" class="type">Odd</p>
     </div>


### PR DESCRIPTION
En inglés "Par" cuando se refiere a número se escribe "Even"
Por ejemplo: https://www.splashlearn.com/math-vocabulary/number-sense/even-and-odd-numbers